### PR TITLE
Refactor read and write functions for new handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 out/
+.DS_Store


### PR DESCRIPTION
In this PR, our goal is to refactor code that is reusable between webhook handlers. We can reuse the code that is needed to read the incoming request, as well as provided the required responses, especially for errors.

- /mutate
- /mutate/sa
- /mutate/ns (coming soon!)

Specifically, we are going to be adding another handler for new namespaces. We want to make sure everything is working as intended before hand. Without refactoring we would have to duplicate code between handlers up to 3x.